### PR TITLE
Remove eslint indent rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,7 +79,6 @@ module.exports = {
         accessibility: 'explicit',
       },
     ],
-    '@typescript-eslint/indent': ['error', 2],
     '@typescript-eslint/interface-name-prefix': 'error',
     '@typescript-eslint/member-delimiter-style': [
       'error',


### PR DESCRIPTION
Correct indentation is already handled by prettier, which for some special
continuation indents, conflicts with this rule.

For example:

```
  constructor(
    public dialogRef: MatDialogRef<
      AddImplementationDialogComponent,
      ImplementationDto
    >,
    @Inject(MAT_DIALOG_DATA) public data: ImplementationDto & DialogData
  ) {}
```
leads to `ESLint: Expected indentation of 4 spaces but found 6.(@typescript-eslint/indent)`