### PR TITLE
[WIP] Reintroduce Tags

### DIFF
--- a/src/app/components/algorithms/algorithm-view/algorithm-view.component.html
+++ b/src/app/components/algorithms/algorithm-view/algorithm-view.component.html
@@ -1,21 +1,7 @@
 <div *ngIf="algorithm" class="m-2">
   <div class="header-container p-2">
     <navigation-breadcrumb [links]="links"></navigation-breadcrumb>
-    <div>
-      <mat-chip-list>
-        <mat-chip
-          *ngFor="let tag of testTags"
-          [removable]="true"
-          (removed)="removeTag(tag)"
-        >
-          {{ tag }}
-          <mat-icon matChipRemove>cancel</mat-icon>
-        </mat-chip>
-        <mat-chip class="clickable-chip" (click)="addTag()">
-          <mat-icon>add</mat-icon>
-        </mat-chip>
-      </mat-chip-list>
-    </div>
+    <app-tags-component [allowRemoving]="true"></app-tags-component>
   </div>
 
   <mat-tab-group>

--- a/src/app/components/generics/generics.module.ts
+++ b/src/app/components/generics/generics.module.ts
@@ -28,6 +28,7 @@ import { ConfirmDialogComponent } from './dialogs/confirm-dialog.component';
 import { LinkInputComponent } from './link-input/link-input.component';
 import { PrologInputComponent } from './property-input/prolog-input.component';
 import { PrologValidator } from './prolog.validator';
+import { TagsComponent } from './tags/tags.component';
 
 @NgModule({
   declarations: [
@@ -40,6 +41,7 @@ import { PrologValidator } from './prolog.validator';
     ConfirmDialogComponent,
     LinkInputComponent,
     PrologValidator,
+    TagsComponent,
   ],
   imports: [
     ReactiveFormsModule,
@@ -62,19 +64,20 @@ import { PrologValidator } from './prolog.validator';
     MatAutocompleteModule,
     MatBadgeModule,
   ],
-  exports: [
-    TextInputComponent,
-    PrologInputComponent,
-    SelectInputComponent,
-    CheckboxInputComponent,
-    DataListComponent,
-    ChipCollectionComponent,
-    RouterModule,
-    MatSortModule,
-    ConfirmDialogComponent,
-    LinkInputComponent,
-    PrologValidator,
-  ],
+    exports: [
+        TextInputComponent,
+        PrologInputComponent,
+        SelectInputComponent,
+        CheckboxInputComponent,
+        DataListComponent,
+        ChipCollectionComponent,
+        RouterModule,
+        MatSortModule,
+        ConfirmDialogComponent,
+        LinkInputComponent,
+        PrologValidator,
+        TagsComponent,
+    ],
   providers: [GenericDataService],
 })
 export class GenericsModule {}

--- a/src/app/components/generics/tags/tags.component.html
+++ b/src/app/components/generics/tags/tags.component.html
@@ -1,0 +1,25 @@
+<div>
+  <mat-chip-list>
+    <mat-chip class="clickable-chip" (click)="addTag()">
+      <mat-icon>add</mat-icon>
+    </mat-chip>
+    <mat-chip
+      *ngFor="let tag of this.tags"
+      [ngStyle]="{'background-color': this.categoryToColor ? this.categoryToColor[tag.category] : 'none' }"
+      [removable]="true"
+      (removed)="removeTag(tag)"
+    >
+      {{ tag.value }}
+      <mat-icon matChipRemove>cancel</mat-icon>
+    </mat-chip>
+    <button mat-icon-button (click)="toggleCategories()" class="help">
+      <mat-icon>help_outline</mat-icon>
+    </button>
+  </mat-chip-list>
+  <div *ngIf="showCategories" class="categories">
+    <div *ngFor="let key of getCategories()" class="m-2">
+      <span class="dot" [ngStyle]="{'background-color': this.categoryToColor ? this.categoryToColor[key] : 'none'}"></span>
+      {{key}}
+    </div>
+  </div>
+</div>

--- a/src/app/components/generics/tags/tags.component.scss
+++ b/src/app/components/generics/tags/tags.component.scss
@@ -1,0 +1,12 @@
+.dot {
+  height: 0.7rem;
+  width: 0.7rem;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.categories {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+}

--- a/src/app/components/generics/tags/tags.component.ts
+++ b/src/app/components/generics/tags/tags.component.ts
@@ -1,0 +1,133 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+} from '@angular/core';
+
+// placeholder content
+const PLACEHOLDER_TAGS: Tag[] = [
+  {
+    category: 'Machine Learning',
+    value: 'Naive Bayes',
+  },
+  {
+    category: 'Machine Learning',
+    value: 'Classification',
+  },
+  {
+    category: 'Topic',
+    value: 'Data Science',
+  },
+  {
+    category: 'Learning',
+    value: 'Eager Learning',
+  },
+];
+
+@Component({
+  selector: 'app-tags-component',
+  templateUrl: './tags.component.html',
+  styleUrls: ['./tags.component.scss'],
+})
+export class TagsComponent implements OnChanges {
+  @Input() allowRemoving = true;
+  @Input() tags: Tag[] = PLACEHOLDER_TAGS;
+
+  @Output() onRemove: EventEmitter<Tag> = new EventEmitter<Tag>();
+
+  showCategories = true;
+  categoryToColor: Record<string, string>;
+  assignedRandoms: number[] = [];
+  // unfortunately there is no quick way to extract angular mat-colors form sass
+  colorPalette: string[] = [
+    '#e57373', // corresponds to mat colors mat-* 300
+    '#f06292',
+    '#ba68c8',
+    '#9575cd',
+    '#7986cb',
+    '#64b5f6',
+    '#4fc3f7',
+    '#4dd0e1',
+    '#4db6ac',
+    '#81c784',
+    '#aed581',
+    '#dce775',
+    '#fff176',
+    '#ffd54f',
+    '#ffb74d',
+    '#ff8a65',
+    '#a1887f',
+    '#e0e0e0',
+    '#90a4ae',
+  ];
+
+  constructor() {
+    // retrieve generated colors from local storage or set them if empty
+    const localStorageKey = 'atlas-tag-categories';
+    if (localStorage.getItem(localStorageKey)) {
+      this.categoryToColor = JSON.parse(localStorage.getItem(localStorageKey));
+    } else {
+      if (!this.categoryToColor) {
+        this.initColors();
+        localStorage.setItem(
+          localStorageKey,
+          JSON.stringify(this.categoryToColor)
+        );
+        console.log(JSON.stringify(this.categoryToColor));
+      }
+    }
+  }
+
+  ngOnChanges(): void {
+    // check if every category has color
+  }
+
+  initColors(): void {
+    this.categoryToColor = {};
+    for (const tag of this.tags) {
+      if (!(tag.category in this.categoryToColor)) {
+        const i = this.getUniqueRandom();
+        this.categoryToColor[tag.category] = this.colorPalette[i];
+      }
+    }
+  }
+
+  getUniqueRandom(): number {
+    const rand = Math.floor(Math.random() * (this.colorPalette.length - 1)) + 1;
+    if (this.assignedRandoms.find((num) => num === rand)) {
+      return this.getUniqueRandom();
+    }
+    this.assignedRandoms.push(rand);
+    return rand;
+  }
+
+  removeTag(tag: Tag): void {
+    this.tags = this.tags.filter((t) => t.value !== tag.value);
+    this.onRemove.emit(tag);
+  }
+
+  addTag(): void {
+    // TODO
+  }
+
+  /**
+   * workaround see: https://github.com/angular/angular/issues/17725
+   */
+  getCategories(): string[] {
+    return Object.keys(this.categoryToColor);
+  }
+
+  toggleCategories(): void {
+    this.showCategories = !this.showCategories;
+  }
+}
+
+export interface Tag {
+  value: string;
+  category: string;
+
+  // not used in backend - will be filled automatically
+  color?: string;
+}


### PR DESCRIPTION
Adds a Tags component which highlightes categories. As colors are not stored in the backend, random mat colors are selected and saved in the local storage of the browser. 

![screen](https://user-images.githubusercontent.com/7521847/89106557-20f79480-d42b-11ea-903c-9e2af46823a2.png)

TODO:
* Add tag dialogue which allows the creation of new tags and categories

Related to [Issue #55](https://github.com/PlanQK/q-tal/issues/55)