### PR TITLE
Improve URL-Functionality in Datalist and Input

### DIFF
--- a/src/app/components/algorithms/algorithm-related-patterns/algorithm-related-patterns.component.html
+++ b/src/app/components/algorithms/algorithm-related-patterns/algorithm-related-patterns.component.html
@@ -10,7 +10,8 @@
                (addElement)="onAddElement()"
                (submitSelectedElements)="onDeleteElements($event)"
                (datalistConfigChanged)="onDatalistConfigChanged($event)"
-               (elementClicked)="onElementClicked($event)">
+               (elementClicked)="onElementClicked($event)"
+               (urlClicked)="onUrlClicked($event)">
     </app-table>
   </div>
 </mdb-card>

--- a/src/app/components/algorithms/algorithm-related-patterns/algorithm-related-patterns.component.ts
+++ b/src/app/components/algorithms/algorithm-related-patterns/algorithm-related-patterns.component.ts
@@ -9,6 +9,7 @@ import { PatternRelationDto } from 'api/models';
 import { AddPatternRelationDialogComponent } from '../dialogs/add-pattern-relation-dialog.component';
 import { UtilService } from '../../../util/util.service';
 import { ConfirmDialogComponent } from '../../generics/dialogs/confirm-dialog.component';
+import { UrlData } from '../../generics/data-list/data-list.component';
 
 @Component({
   selector: 'app-algorithm-related-patterns',
@@ -183,6 +184,11 @@ export class AlgorithmRelatedPatternsComponent implements OnInit {
         }
       }
     });
+  }
+
+  onUrlClicked(urlData: UrlData): void {
+    // No check needed since publications have only one url-field called 'pattern'
+    window.open(urlData.element['pattern'], '_blank');
   }
 
   generateTableObjects(): void {

--- a/src/app/components/algorithms/algorithm-related-patterns/algorithm-related-patterns.component.ts
+++ b/src/app/components/algorithms/algorithm-related-patterns/algorithm-related-patterns.component.ts
@@ -187,7 +187,7 @@ export class AlgorithmRelatedPatternsComponent implements OnInit {
   }
 
   onUrlClicked(urlData: UrlData): void {
-    // No check needed since publications have only one url-field called 'pattern'
+    // No check needed since pattern-relations have only one url-field called 'pattern'
     window.open(urlData.element['pattern'], '_blank');
   }
 

--- a/src/app/components/generics/data-list/data-list.component.html
+++ b/src/app/components/generics/data-list/data-list.component.html
@@ -67,18 +67,8 @@
       <!-- One column for each needed data variable value -->
       <td class="crop align-middle" *ngFor="let variableName of variableNames"
           (click)="onElementClicked(dataEntry)">
-        <!-- Check if element is a URL -->
-        <div
-          *ngIf="externalLinkVariables && externalLinkVariables.includes(variableName); then isExternalLink else isBasicDataEntry"></div>
-        <!-- If element is external link, then click should open link in a new tab -->
-        <ng-template #isExternalLink>
-          <a class="table-url" [href]="dataEntry[variableName]" target="_blank"
-             (click)="$event.stopPropagation()">{{ dataEntry[variableName] }}</a>
-        </ng-template>
-        <!-- If element is basic -->
-        <ng-template #isBasicDataEntry>
-          <a>{{ dataEntry[variableName] }}</a>
-        </ng-template>
+        <!-- Apply URL-Class and Event if variable has a link -->
+        <a [ngClass]="{'table-url': isLink(variableName)}" (click)="isLink(variableName) && onUrlClicked($event, dataEntry, variableName)">{{ dataEntry[variableName] }}</a>
       </td>
       <td *ngIf="allowSelection">
         <button mat-icon-button class="delete-small"

--- a/src/app/components/generics/data-list/data-list.component.scss
+++ b/src/app/components/generics/data-list/data-list.component.scss
@@ -120,6 +120,13 @@ mat-grid-list {
   color: red;
 }
 
+a.table-url {
+  color: dodgerblue;
+}
+
 a.table-url:hover {
+  text-decoration: underline;
+  color: mat-color($qc-atlas-ui-primary);
+  cursor: pointer;
   text-decoration: underline;
 }

--- a/src/app/components/generics/data-list/data-list.component.ts
+++ b/src/app/components/generics/data-list/data-list.component.ts
@@ -21,6 +21,7 @@ export class DataListComponent implements OnInit {
   @Input() paginatorConfig: any;
   @Input() emptyTableMessage = 'No elements found';
   @Output() elementClicked = new EventEmitter<any>();
+  @Output() urlClicked = new EventEmitter<UrlData>();
   @Output() addElement = new EventEmitter<void>();
   @Output() submitSelectedElements = new EventEmitter<DeleteParams>(); // changed
   @Output() pageChange = new EventEmitter<string>();
@@ -44,6 +45,13 @@ export class DataListComponent implements OnInit {
     return this.data.length === this.selection.selected.length;
   }
 
+  isLink(variableName): boolean {
+    return (
+      this.externalLinkVariables &&
+      this.externalLinkVariables.includes(variableName)
+    );
+  }
+
   // Toggle all check boxes
   masterToggle(): void {
     const isAllSelected = this.isAllSelected();
@@ -64,6 +72,15 @@ export class DataListComponent implements OnInit {
   onElementClicked(element): void {
     this.elementClicked.emit(element);
     this.selection.clear();
+  }
+
+  onUrlClicked(event, element, variableName): void {
+    event.stopPropagation();
+    const urlData: UrlData = {
+      element,
+      variableName,
+    };
+    this.urlClicked.emit(urlData);
   }
 
   // changed
@@ -166,4 +183,9 @@ export interface LinkObject {
   subtitle: string;
   displayVariable: string;
   data: any[];
+}
+
+export interface UrlData {
+  element: any;
+  variableName: string;
 }

--- a/src/app/components/generics/property-input/text-input.component.html
+++ b/src/app/components/generics/property-input/text-input.component.html
@@ -1,4 +1,4 @@
-<div [ngClass]="{'url-input': (isLink && !isBeingEdited)}">
+<div [ngClass]="{'url-input': (isLink && !isBeingEdited && value)}">
   <mat-form-field>
     <mat-label class="input-label">{{ name }}</mat-label>
     <input
@@ -7,7 +7,7 @@
       [readonly]="!isBeingEdited"
       [(ngModel)]="value"
       matInput
-      (click)="(isLink && !isBeingEdited) ? openLink() : false"
+      (click)="(isLink && !isBeingEdited && value) ? openLink() : false"
     />
     <textarea
       *ngIf="multiline"

--- a/src/app/components/publications/publication-list/publication-list.component.html
+++ b/src/app/components/publications/publication-list/publication-list.component.html
@@ -12,6 +12,7 @@
                [paginatorConfig]=paginatorConfig
                [emptyTableMessage]="'No publications found'"
                (elementClicked)="onElementClicked($event)"
+               (urlClicked)="onUrlClicked($event)"
                (addElement)="onAddElement()"
                (submitSelectedElements)="onDeleteElements($event)"
                (datalistConfigChanged)="getPublications($event)"

--- a/src/app/components/publications/publication-list/publication-list.component.ts
+++ b/src/app/components/publications/publication-list/publication-list.component.ts
@@ -9,6 +9,7 @@ import { AddPublicationDialogComponent } from '../dialogs/add-publication-dialog
 import {
   DeleteParams,
   QueryParams,
+  UrlData,
 } from '../../generics/data-list/data-list.component';
 
 @Component({
@@ -61,6 +62,11 @@ export class PublicationListComponent implements OnInit {
 
   onElementClicked(publication: any): void {
     this.router.navigate(['publications', publication.id]);
+  }
+
+  onUrlClicked(urlData: UrlData): void {
+    // No check needed since publications have only one url-field called 'url'
+    window.open(urlData.element['url'], '_blank');
   }
 
   onAddElement(): void {


### PR DESCRIPTION
- Fixed Bug in Text-Input-Component, where empty URLs could be clicked
- Adjusted functionality of URLs in datalist. Now clicking an URL will trigger a event, which can be implemented in the parent, allowing more flexibility for using URLs (for example the Name of an Algorithm can be an URL in the Algorihm Relation List, allowing the navigation to the related algorithm)